### PR TITLE
add support for cpython-mingw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2022 Mitchell Kline
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,15 @@ VS_PROJ = LIBUSB_DIR / "msvc" / "libusb_dll_2019.vcxproj"
 
 PACKAGE_NAME = 'libusb_package'
 
+# check for mingw environment (recommended method from msys2.org/docs/python)
+IS_CPYTHON_MINGW = os.name == "nt" and sysconfig.get_platform().startswith("mingw")
+
+if IS_CPYTHON_MINGW:
+    # if running cpython-mingw, path names get butchered in windows-posix conversion (or lack thereof),
+    # so fix them here
+    print("cpython-mingw detected!")
+    os.environ['ACLOCAL_PATH'] = os.environ.get('ACLOCAL_PATH').replace('\\', '/')
+
 # Check if we're running 64-bit Python
 IS_64_BIT = sys.maxsize > 2**32
 
@@ -69,6 +78,7 @@ def get_relative_sibling_path(from_path: Path, to_path: Path) -> Path:
     # Combine into the final path.
     result = up_path / to_path_abs.relative_to(common)
     return result
+
 
 # Based on code from https://github.com/libdynd/dynd-python
 class libusb_build_ext(build_ext):
@@ -103,7 +113,7 @@ class libusb_build_ext(build_ext):
     try:
         # Change to the build directory during the build.
         with temp_chdir(build_temp):
-            if sys.platform != 'win32':
+            if sys.platform != 'win32' or IS_CPYTHON_MINGW:
                 # Set optimization and enable extra warnings.
                 # These flags are taken from libusb/.private/ci-build.sh.
                 cflags = [
@@ -153,6 +163,8 @@ class libusb_build_ext(build_ext):
 
                 if sys.platform == 'darwin':
                     shared_library_suffix = 'dylib'
+                elif sys.platform == 'cygwin' or sys.platform == 'win32':
+                    shared_library_suffix = 'dll'
                 else:
                     shared_library_suffix = 'so'
                 lib_paths = [Path(g) for g in glob.glob(f"libusb/.libs/*.{shared_library_suffix}")]


### PR DESCRIPTION
I'm adding support for cpython-mingw since there was no wheel available in PyPI.  According to the [MSYS2 doc](msys2.org/docs/python):

> C extensions are not compatible with the official CPython, which means pip can't use binary wheels from PyPI and packages have to be build when installing them.

The source build did not work in mingw because it wasn't expecting to use gcc from a windows environment.

There is one ugly hack due to cpython-mingw butchering the path names in a windows-posix conversion. This is only necessary if building from a mingw shell using `os.name=nt` python. If using `os.name=posix` python (like that installed by MSYS2 with `pacman -S python`), the hack is unnecessary (and also won't be applied).