### PR TITLE
Add Pyinstaller hook for libusb dynamic lib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+# Entry Points for PyInstaller
+[options.entry_points]
+pyinstaller40 =
+    hook-dirs = libusb_package.__pyinstaller:get_hook_dirs
+
 [metadata]
 name = libusb-package
 description = Package containing libusb so it can be installed via Python package managers

--- a/src/libusb_package/__pyinstaller/__init__.py
+++ b/src/libusb_package/__pyinstaller/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/src/libusb_package/__pyinstaller/__init__.py
+++ b/src/libusb_package/__pyinstaller/__init__.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2022 Mitchell Kline
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 def get_hook_dirs():

--- a/src/libusb_package/__pyinstaller/hook-libusb_package.py
+++ b/src/libusb_package/__pyinstaller/hook-libusb_package.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# copy the libusb shared library to the package root directory
+binaries = collect_dynamic_libs('libusb_package', destdir='.')

--- a/src/libusb_package/__pyinstaller/hook-libusb_package.py
+++ b/src/libusb_package/__pyinstaller/hook-libusb_package.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2022 Mitchell Kline
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from PyInstaller.utils.hooks import collect_dynamic_libs
 
 # copy the libusb shared library to the package root directory


### PR DESCRIPTION
The addition of this hook will cause pyinstaller to copy the required dynamic library to the root directory of the built executable package.

Without this hook, the pyinstaller spec file must include the line:

```python
binaries += collect_dynamic_libs('libusb_package', destdir='.')
```