### PR TITLE
Build libusb out of tree build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ if available.
 
 You can also install from a clone of the git repository by running `pip install .` from the repository root directory.
 Editable installs are supported. Please note that running `setup.py` directly is no longer supported for PEP 517
-compliant packages. When building from the repo, because libusb 1.0.24 does not support out of tree builds, the build is
-done in-place in the `src/libusb` directory. `make clean` is run before compiling to ensure a clean build.
+compliant packages. Building libusb is done out of tree in an automatically created build directory for libusb 1.0.25
+and later.
 
 
 ## APIs
@@ -42,7 +42,7 @@ There are four public functions exported by `libusb_package`.
 
 - `find(*args, **kwargs)`: Wrapper around pyusb's `usb.core.find()` that sets the `backend`
     parameter to a libusb1 backend created from the libusb library included in `libusb_package`.
-    All other parameters are passed unmodified
+    All other parameters are passed unmodified.
 
 - `get_libusb1_backend()`: Returns a `pyusb` backend object for the libusb version contained
     in `libusb_package`.

--- a/scripts/vsenv.bat
+++ b/scripts/vsenv.bat
@@ -1,6 +1,6 @@
-rem From: https://renenyffenegger.ch/notes/development/tools/scripts/personal/vsenv_bat
-
 @echo off
+
+rem From: https://renenyffenegger.ch/notes/development/tools/scripts/personal/vsenv_bat
 
 rem
 rem Uncomment setting VSCMD_DEBUG to enable debugging to output

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2022 Mitchell Kline
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -97,12 +97,10 @@ class libusb_build_ext(build_ext):
         build_lib = ROOT_DIR / Path(build_py.get_package_dir(PACKAGE_NAME)).parent
     else:
         build_lib = Path(os.path.abspath(self.build_lib))
-#     build_temp = Path(os.path.abspath(self.build_temp))
 
-    # Build in-tree for the time being. libusb commit 1001cb5 adds support for out of tree builds, but
-    # this is not yet supported in an existing release. Once libusb version 1.0.25 is released, we can
-    # build out of tree.
-    build_temp = LIBUSB_DIR
+    # Build out of tree. Requires libusb commit 1001cb5 which adds support for out of tree builds, present
+    # in libusb 1.0.25 and later.
+    build_temp = Path(os.path.abspath(self.build_temp))
 
     print(f"build_temp = {build_temp}")
     print(f"build_lib = {build_lib}")
@@ -156,7 +154,6 @@ class libusb_build_ext(build_ext):
                     self.spawn(['env']) # Dump environment for debugging purposes.
                     self.spawn(['bash', str(BOOTSTRAP_SCRIPT)])
                     self.spawn(['bash', str(CONFIGURE_SCRIPT), *extra_configure_args])
-                    self.spawn(['make', 'clean'])
                     self.spawn(['make', f'-j{os.cpu_count() or 4}', 'all'])
                 except Exception as err:
                     # Exception is caught here and reraised as our specific Exception class because the actual

--- a/setup.py
+++ b/setup.py
@@ -175,10 +175,20 @@ class libusb_build_ext(build_ext):
             else:
                 platform = "x64" if IS_64_BIT else "x86"
                 config = "Release"
+                properties = {
+                    "Configuration": config,
+                    "Platform": platform,
+                    "IntermediateOutputPath": str(build_temp / platform / "obj") + "\\", # Must end with trailing slash.
+                    "OutDir": str(build_temp / platform / config) + "\\",
+                    #IntermediateOutputPath
+                    #OutputPath
+                    }
+
+                property_values = ';'.join(f'{k}={v}' for k, v in properties.items())
+                msbuild_cmd = f'msbuild -p:{property_values} {VS_PROJ}'
 
                 try:
-                    self.spawn(['cmd.exe', '/c', f'{VSENV_SCRIPT} && '
-                            f'msbuild -p:Configuration={config} -p:Platform={platform} {VS_PROJ}'])
+                    self.spawn(['cmd.exe', '/c', f'{VSENV_SCRIPT} && {msbuild_cmd}'])
                 except Exception as err:
                     # See comment above for notes about this exception handler.
                     raise LibusbBuildError(str(err)) from err


### PR DESCRIPTION
libusb 1.0.25 added support for building it out of tree. This is the default behaviour for setuptools, and is much cleaner.