### PR TITLE
Update cibuildwheel action to 2.11.2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.7'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.11.2
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This should enable the building of wheels for Python 3.11 (see #11).

Assuming everything goes well here, please upload the Python 3.11 wheels to PyPI when you have some time.

---

In the future, we might want to consider just specifying the major version number, as the cibuildwheel action is probably something we always want to run the latest available (as long as it doesn't do any breaking changes).