### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,23 +35,23 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.11.3
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=42",
     "setuptools_scm[toml]>=6.2",
     "wheel",
+    "tomli",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,11 @@ classifiers =
     Operating System :: POSIX
     Operating System :: Unix
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: System :: Hardware :: Universal Serial Bus (USB)
     Typing :: Typed
 project_urls =
@@ -37,9 +37,7 @@ project_urls =
 
 [options]
 packages = find:
-install_requires =
-    importlib_resources; python_version < "3.7"
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src


### PR DESCRIPTION
- Update cibuildwheel to a version that builds for Python 3.11.
- Increment other action versions
- Change version of Python used by cibuildwheel to 3.9.
- Add missing `tomli` build dependency.
- Add Python 3.11 and drop Python 3.6 in the package metadata.