### PR TITLE
replace deprecated importlib.resources API usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ include_package_data = True
 package_dir =
     =src
 zip_safe = False
+install_requires =
+    importlib_resources
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Switch away from the deprecated importlib.resources is_resource() and path() APIs. The importlib_resources package is used to get the new functionality on all supported versions of Python.

Also enable annotations future so type names don't have to be quoted.