### PR TITLE
Add support for Python 3.12 by updating pypa/cibuildwheel.

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.16.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: System :: Hardware :: Universal Serial Bus (USB)
     Typing :: Typed
 project_urls =


### PR DESCRIPTION
Initial Python 3.12 support added to pypa/cibuildwheel@v2.13.0:
https://github.com/pypa/cibuildwheel/releases/tag/v2.13.0

But final 3.12.0 support added to pypa/cibuildwheel@v2.16.2, which is the latest release:
https://github.com/pypa/cibuildwheel/releases/tag/v2.16.2 

Fixes https://github.com/pyocd/libusb-package/issues/16.