### PR TITLE
Add test step to cibuildwheel.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ ignore_missing_imports = true
 
 [tool.cibuildwheel]
 before-build = "python -m pip install --upgrade pip wheel setuptools setuptools_scm"
+test-requires = "pyusb"
+test-command = 'python {project}/test.py'
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Looking into adding tests (issue https://github.com/pyocd/libusb-package/issues/19), and it looks like we can run a test step in cibuildwheel after each wheel is built, simple! 🥳
https://cibuildwheel.readthedocs.io/en/v2.16.2/options/#testing

So I've added `pyusb` as a test requirement and it runs `python test.py`.

- Is that the best current way to test the wheels?
- Is there something else this should do?

I was planning to add this as part of PR https://github.com/pyocd/libusb-package/pull/20, but unfortunately the tests are failing on Linux, so I didn't want that to be a blocker for that PR.

This PR is running on top of the main branch without any other modifications, to test the current wheels, which I assume should be working.

Test result from my fork: https://github.com/carlosperate/libusb-package/actions/runs/6975861223/job/18983558875
```
Building cp37-manylinux_x86_64 wheel
CPython 3.7 manylinux x86_64
...
  Collecting pyusb
    Downloading pyusb-1.2.1-py3-none-any.whl (58 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.4/58.4 kB 4.8 MB/s eta 0:00:00
  Installing collected packages: pyusb
  Successfully installed pyusb-1.2.1
      + mkdir -p /tmp/tmp.G43sXfIgjj/test_cwd
      + sh -c 'python /project/test.py'
  Path to included library: /tmp/tmp.G43sXfIgjj/venv/lib/python3.7/site-packages/libusb_package/libusb-1.0.so
  Unable to load libusb backend!
```

https://github.com/pyocd/libusb-package/blob/7a62b644f3cc075a37e8d2e255ee9941ce2ca752/test.py#L13-L17
https://github.com/pyocd/libusb-package/blob/7a62b644f3cc075a37e8d2e255ee9941ce2ca752/src/libusb_package/__init__.py#L66-L87