### PR TITLE
Update cibuildwheel to build wheels for Python 3.13

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.21.3
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: System :: Hardware :: Universal Serial Bus (USB)
     Typing :: Typed
 project_urls =


### PR DESCRIPTION
Hello,
Updating cibuildwheel to version 2.21 enables building wheels for Python 3.13
As a side-effect, this PR fixes #16 and https://github.com/pyocd/pyOCD/issues/1726

As for testing, I've used the `.find` method to find JLink and CMSIS-DAP debuggers. (USB Devices with VID  0x1366 and 0x1FC9 respectively)
Operating systems: Win11, Ubuntu 22, and MacOS 14
Python versions: 3.8 - 3.13 (3.13 still with GIL enabled)

Wheels can be downloaded here: https://github.com/Salamist/libusb-package/actions/runs/11359288419
