### PR TITLE
Bump-up version of cibuildwheel to support Python3.14

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.3.1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: System :: Hardware :: Universal Serial Bus (USB)
     Typing :: Typed
 project_urls =


### PR DESCRIPTION
Using newer version of cibuildwheel will generate wheels also for Python3.14
This should also solve issue #28 

I've performed basic tests on Windows. Could maintainers pls run Linux and Mac?