### PR TITLE
Bump up github actions (Node.js 24)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,17 +35,17 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         name: Install Python
         with:
           python-version: '3.9'
@@ -53,7 +53,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.1.0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheelhouse-${{ matrix.os }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Using Node.js 24 instead of deprecated Node.js 20