### PR TITLE
libusb 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This means the libusb build requirements must be installed:
 
 - Linux and macOS: autoconf, automake, libtool, and m4. As mentioned above, libusb is built without udev support,
     so libudev-dev is not required on Linux.
-- Windows: Visual Studio 2019 (Community is ok).
+- Windows: Visual Studio 2019 or later (Community is ok).
 
 If the libusb build fails when installing from a source distribution, the `libusb-package` install _will still
 succeed_. In this case, an "empty" `libusb-package` is installed that doesn't contain a libusb shared library.
@@ -32,8 +32,8 @@ if available.
 
 You can also install from a clone of the git repository by running `pip install .` from the repository root directory.
 Editable installs are supported. Please note that running `setup.py` directly is no longer supported for PEP 517
-compliant packages. When building from the repo, because libusb 1.0.24 does not support out of tree builds, the build is
-done in-place in the `src/libusb` directory. `make clean` is run before compiling to ensure a clean build.
+compliant packages. Building libusb is done out of tree in an automatically created build directory for libusb 1.0.25
+and later.
 
 
 ## APIs
@@ -42,7 +42,7 @@ There are four public functions exported by `libusb_package`.
 
 - `find(*args, **kwargs)`: Wrapper around pyusb's `usb.core.find()` that sets the `backend`
     parameter to a libusb1 backend created from the libusb library included in `libusb_package`.
-    All other parameters are passed unmodified
+    All other parameters are passed unmodified.
 
 - `get_libusb1_backend()`: Returns a `pyusb` backend object for the libusb version contained
     in `libusb_package`.
@@ -64,7 +64,7 @@ Both `get_libusb1_backend()` and `get_library_path()` cache their return values.
 ## Versioning
 
 The version of libusb-package is composed of the libusb version plus an additional field for
-the version of the Python code. For instance, 1.0.24.0. The Python code version will be reset
+the version of the Python code. For instance, 1.0.30.0. The Python code version will be reset
 to 0 when the libusb version is incremented for new libusb release.
 
 

--- a/scripts/vsenv.bat
+++ b/scripts/vsenv.bat
@@ -1,6 +1,6 @@
-rem From: https://renenyffenegger.ch/notes/development/tools/scripts/personal/vsenv_bat
-
 @echo off
+
+rem From: https://renenyffenegger.ch/notes/development/tools/scripts/personal/vsenv_bat
 
 rem
 rem Uncomment setting VSCMD_DEBUG to enable debugging to output

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021 Chris Reed
 # Copyright (c) 2022 Mitchell Kline
+# Copyright (c) 2026 Arm Limited
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -39,7 +40,7 @@ VSENV_SCRIPT = SCRIPTS_DIR / "vsenv.bat"
 LIBUSB_DIR = ROOT_DIR / "src" / "libusb"
 BOOTSTRAP_SCRIPT = LIBUSB_DIR / "bootstrap.sh"
 CONFIGURE_SCRIPT = LIBUSB_DIR / "configure"
-VS_PROJ = LIBUSB_DIR / "msvc" / "libusb_dll_2019.vcxproj"
+VS_PROJ = LIBUSB_DIR / "msvc" / "libusb_dll.vcxproj"
 
 PACKAGE_NAME = 'libusb_package'
 
@@ -98,12 +99,9 @@ class libusb_build_ext(build_ext):
         build_lib = ROOT_DIR / Path(build_py.get_package_dir(PACKAGE_NAME)).parent
     else:
         build_lib = Path(os.path.abspath(self.build_lib))
-#     build_temp = Path(os.path.abspath(self.build_temp))
 
-    # Build in-tree for the time being. libusb commit 1001cb5 adds support for out of tree builds, but
-    # this is not yet supported in an existing release. Once libusb version 1.0.25 is released, we can
-    # build out of tree.
-    build_temp = LIBUSB_DIR
+    # Build out of tree. Requires libusb 1.0.25 and later which adds support for out of tree builds.
+    build_temp = Path(os.path.abspath(self.build_temp))
 
     print(f"build_temp = {build_temp}")
     print(f"build_lib = {build_lib}")
@@ -157,7 +155,6 @@ class libusb_build_ext(build_ext):
                     self.spawn(['env']) # Dump environment for debugging purposes.
                     self.spawn(['bash', str(BOOTSTRAP_SCRIPT)])
                     self.spawn(['bash', str(CONFIGURE_SCRIPT), *extra_configure_args])
-                    self.spawn(['make', 'clean'])
                     self.spawn(['make', f'-j{os.cpu_count() or 4}', 'all'])
                 except Exception as err:
                     # Exception is caught here and reraised as our specific Exception class because the actual
@@ -179,16 +176,25 @@ class libusb_build_ext(build_ext):
             else:
                 platform = "x64" if IS_64_BIT else "x86"
                 config = "Release"
+                # Keep MSBuild outputs out of src/libusb by redirecting IntDir. libusb_dll.vcxproj derives
+                # OutDir from IntDir, so the DLL is emitted next to this directory in a sibling "dll" dir.
+                int_dir = build_temp / "obj"
+                out_dir = int_dir.parent / "dll"
+                properties = {
+                    "Configuration": config,
+                    "Platform": platform,
+                    "IntDir": str(int_dir) + "\\", # Must end with trailing slash.
+                }
+                property_values = ';'.join(f'{k}={v}' for k, v in properties.items())
+                msbuild_cmd = f'msbuild -p:{property_values} {VS_PROJ}'
 
                 try:
-                    self.spawn(['cmd.exe', '/c', f'{VSENV_SCRIPT} && '
-                            f'msbuild -p:Configuration={config} -p:Platform={platform} {VS_PROJ}'])
+                    self.spawn(['cmd.exe', '/c', f'{VSENV_SCRIPT} && {msbuild_cmd}'])
                 except Exception as err:
                     # See comment above for notes about this exception handler.
                     raise LibusbBuildError(str(err)) from err
 
-                out_dir = "x64" if IS_64_BIT else "Win32"
-                lib_paths = [Path(g) for g in glob.glob(f"{out_dir}\\{config}\\dll\\*.dll")]
+                lib_paths = [Path(g) for g in glob.glob(f"{out_dir}\\*.dll")]
 
             if not lib_paths:
                 raise LibusbBuildError(f"libusb failed to build: no libraries found in {build_temp}")

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ class libusb_build_ext(build_ext):
                 # Sort libs by filename length. The shortest filename should be the most generic version.
                 lib_paths = sorted(lib_paths, key=lambda x: len(x.name))
             else:
+                toolset = "v143"  # Use the latest toolset available in Visual Studio 2022.
                 platform = "x64" if IS_64_BIT else "x86"
                 config = "Release"
                 # Keep MSBuild outputs out of src/libusb by redirecting IntDir. libusb_dll.vcxproj derives
@@ -181,8 +182,9 @@ class libusb_build_ext(build_ext):
                 int_dir = build_temp / "obj"
                 out_dir = int_dir.parent / "dll"
                 properties = {
-                    "Configuration": config,
+                    "PlatformToolset": toolset,
                     "Platform": platform,
+                    "Configuration": config,
                     "IntDir": str(int_dir) + "\\", # Must end with trailing slash.
                 }
                 property_values = ';'.join(f'{k}={v}' for k, v in properties.items())


### PR DESCRIPTION
- update libusb submodule to v.1.0.30 tag
- migrate setup.py to libusb 1.0.30
  - update to libusb_dll.vcxproj (use VS 20222 toolset)
  - switch to out of tree build